### PR TITLE
Add IPv6 Extension parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -236,7 +236,7 @@ checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
 
 [[package]]
 name = "pktstrings"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "cfg-if",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -236,7 +236,7 @@ checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
 
 [[package]]
 name = "pktstrings"
-version = "1.0.5"
+version = "1.1.0"
 dependencies = [
  "cfg-if",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pktstrings"
-version = "1.0.4"
+version = "1.0.5"
 edition = "2021"
 rust-version = "1.60"
 authors = ["Pete Wicken <petewicken@gmail.com>"]
@@ -9,11 +9,11 @@ readme = "README.md"
 homepage = "https://github.com/JamoBox/pktstrings"
 repository = "https://github.com/JamoBox/pktstrings"
 license = "MIT"
-keywords = ["packet-analyzer", "network-monitoring", "network-analysis", "ctf-tools"]
+keywords = ["packet-analyzer", "pcap", "sniffing", "packet"]
 categories = ["command-line-utilities", "network-programming"]
 
 [dependencies]
-clap = {version = "4", features = ["derive", "cargo"]}
+clap = {version = "4", features = ["derive"]}
 pcap = "0"
 colored = "2"
 dns-lookup = {version = "1", optional = true}
@@ -23,6 +23,9 @@ libc = "0"
 [features]
 bland = ["colored/no-color"]
 resolve = ["dns-lookup"]
+
+[profile.dev]
+split-debuginfo = "packed"
 
 [profile.release]
 lto = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pktstrings"
-version = "1.0.5"
+version = "1.1.0"
 edition = "2021"
 rust-version = "1.60"
 authors = ["Pete Wicken <petewicken@gmail.com>"]

--- a/README.md
+++ b/README.md
@@ -46,6 +46,6 @@ Default install location is `~/.cargo/bin/pktstrings`.
 Run pktstrings with `-h` for help and available options.
 
 ## TODO (maybe):
-- PCAPNG support
 - Other string encodings
-- Better protocol support (e.g. IPv6 header parsing?)
+- Support more protocols
+- Full PCAPNG support

--- a/README.md
+++ b/README.md
@@ -45,8 +45,7 @@ To install from cloned source:
 Default install location is `~/.cargo/bin/pktstrings`.
 Run pktstrings with `-h` for help and available options.
 
-## TODO:
-- More optimisations
-- Possibly PCAPNG
-- Other encodings
+## TODO (maybe):
+- PCAPNG support
+- Other string encodings
 - Better protocol support (e.g. IPv6 header parsing?)

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ use pcap::{Activated, Capture, Device};
 use std::path::Path;
 
 mod net;
+mod proto;
 
 const HELP_NUMBER: &str = "Number of printable characters to display";
 const HELP_BLOCK_PRINT: &str = "Print string blocks without packet info on each line";

--- a/src/net.rs
+++ b/src/net.rs
@@ -73,7 +73,9 @@ fn handle_eth(pkt: &Packet, offset: usize, pktsum: &mut PacketSummary) -> Result
 
     pktsum.ethertype = match ethertype {
         Some(VLAN) => {
-            pktsum.vlan_id = get_field(pkt.data, offset + 14, 16).map(|x| x as u16 & 0xfff).ok();
+            pktsum.vlan_id = get_field(pkt.data, offset + 14, 16)
+                .map(|x| x as u16 & 0xfff)
+                .ok();
             vlan_padding = 4;
 
             get_field(pkt.data, offset + 16, 16).map(|x| x as u16).ok()

--- a/src/net.rs
+++ b/src/net.rs
@@ -99,12 +99,42 @@ fn handle_ipv4(pkt: &Packet, offset: usize, pktsum: &mut PacketSummary) -> Resul
 }
 
 fn handle_ipv6(pkt: &Packet, offset: usize, pktsum: &mut PacketSummary) -> Result<usize, String> {
-    pktsum.next_proto = Some(pkt.data[offset + 6]);
+    let mut next_offset = offset + 40;
+    let mut next_proto = pkt.data[offset + 6];
+
     pktsum.l3_src = get_field(pkt, offset + 8, 128).ok();
     pktsum.l3_dst = get_field(pkt, offset + 24, 128).ok();
 
-    // TODO: parse headers
-    Ok(offset + 40)
+    // walk until we hit bottom of IPv6 header stack
+    let mut bos = false;
+    while !bos {
+        match next_proto {
+            0 | 43 | 60 => {
+                next_proto = pkt[next_offset];
+                next_offset += 8 + (pkt[next_offset + 1] * 8) as usize;
+            }
+            44 => {
+                let frag = get_field(pkt, next_offset + 2, 16)
+                    .map(|x| x as u16 & 0xff8)
+                    .unwrap();
+                next_proto = pkt[next_offset];
+                next_offset += 8;
+
+                // if we aren't on the first fragment then pass an error up
+                // to prevent the protocol walker from continuing to try and parse
+                // whatever data that follows as an L4 header.
+                if frag != 0 {
+                    pktsum.next_proto = Some(next_proto);
+                    return Err("IPv6 Frag, halt parsing".to_string());
+                }
+                bos = true; // prevent re-looping as we will always be BoS here
+            }
+            _ => bos = true,
+        };
+    }
+
+    pktsum.next_proto = Some(next_proto);
+    Ok(next_offset)
 }
 
 fn handle_unknown(
@@ -343,16 +373,38 @@ mod tests {
             len: 97,
         },
         data: &[
+            /* Ethernet + Dot1Q */
             0x0, 0x0, 0x0, 0x0, 0x0, 0x1, // dst
             0xff, 0xff, 0xff, 0xff, 0xff, 0xff, // src
             0x81, 0x0, // 802.1q
             0x5f, 0xff, // VLAN ID 4095
             0x86, 0xdd, // TPID IPv6
-            0x60, 0x0, 0x0, 0x0, 0x0, 0x27, 0x6, 0x40, // default headers
+            /* IPv6 */
+            0x60, 0x0, 0x0, 0x0, 0x0, 0x27, 0x0, 0x40, // defaults + Hop-By-Hop Next Header
             0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
             0x1, // src ::1
             0x73, 0x57, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1,
             0x23, // dst 7357::123
+            /* Hop-By-Hop */
+            0x3c, // Next Header
+            0x01, // Hdr Ext Len
+            b'A', b'A', b'A', b'A', b'A', b'A', b'A', b'A', b'A', b'A', b'A', b'A', b'A', b'A',
+            /* Destination Options */
+            0x2b, // Next Header
+            0x01, // Hdr Ext Len
+            b'B', b'B', b'B', b'B', b'B', b'B', b'B', b'B', b'B', b'B', b'B', b'B', b'B', b'B',
+            /* Routing */
+            0x2c, // Next Header
+            0x01, // Hdr Ext Len
+            0x04, // Routing Type
+            0x02, // Segments Left
+            b'C', b'C', b'C', b'C', b'C', b'C', b'C', b'C', b'C', b'C', b'C', b'C',
+            /* Fragment */
+            0x6,  // Next Header
+            0x00, // Reserved
+            0x00, 0x00, // Fragment Offset
+            0x00, 0x00, 0x04, 0xd2, // Identification
+            /* TCP */
             0x0, 0x50, // sport 80
             0x14, 0xeb, // dport 5355
             0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, // headers
@@ -463,7 +515,7 @@ mod tests {
     #[test]
     fn test_handle_ipv6() {
         let mut pktsum = PacketSummary::new();
-        let expected = 58;
+        let expected = 114;
 
         let result = handle_ipv6(&REF_V6_PACKET, 18, &mut pktsum);
         assert_eq!(result.unwrap(), expected, "offset");

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -23,21 +23,32 @@ impl ProtoResolver for Ethertype {
 /* IP Next Proto/Header */
 pub type NextProto = u8;
 
+pub const HOPOPT: NextProto = 0;
 pub const ICMP: NextProto = 1;
 pub const TCP: NextProto = 6;
 pub const UDP: NextProto = 17;
 pub const DCCP: NextProto = 33;
-pub const ICMPV6: NextProto = 58;
+pub const IPV6_ROUTE: NextProto = 43;
+pub const IPV6_FRAG: NextProto = 44;
+pub const AH: NextProto = 51;
+pub const IPV6_ICMP: NextProto = 58;
+pub const IPV6_NONXT: NextProto = 59;
+pub const IPV6_OPTS: NextProto = 60;
 pub const SCTP: NextProto = 132;
 
 impl ProtoResolver for NextProto {
     fn resolve(&self) -> String {
         match *self {
+            HOPOPT => "Hop-by-Hop".to_string(),
             ICMP => "ICMP".to_string(),
             TCP => "TCP".to_string(),
             UDP => "UDP".to_string(),
             DCCP => "DCCP".to_string(),
-            ICMPV6 => "ICMPv6".to_string(),
+            IPV6_ROUTE => "Routing".to_string(),
+            IPV6_FRAG => "Fragmented".to_string(),
+            IPV6_ICMP => "ICMPv6".to_string(),
+            IPV6_NONXT => "No Next Hdr".to_string(),
+            IPV6_OPTS => "Dst Opts".to_string(),
             SCTP => "SCTP".to_string(),
             _ => self.to_string(),
         }

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -1,0 +1,64 @@
+pub trait ProtoResolver {
+    fn resolve(&self) -> String;
+}
+
+/* Ethertypes */
+pub type Ethertype = u16;
+
+pub const IPV4: Ethertype = 0x0800;
+pub const IPV6: Ethertype = 0x86dd;
+pub const VLAN: Ethertype = 0x8100;
+
+impl ProtoResolver for Ethertype {
+    fn resolve(&self) -> String {
+        match *self {
+            IPV4 => "IPv4".to_string(),
+            IPV6 => "IPv6".to_string(),
+            VLAN => "VLAN".to_string(),
+            _ => format!("0x{self:04x}"),
+        }
+    }
+}
+
+/* IP Next Proto/Header */
+pub type NextProto = u8;
+
+pub const ICMP: NextProto = 1;
+pub const TCP: NextProto = 6;
+pub const UDP: NextProto = 17;
+pub const DCCP: NextProto = 33;
+pub const ICMPV6: NextProto = 58;
+pub const SCTP: NextProto = 132;
+
+impl ProtoResolver for NextProto {
+    fn resolve(&self) -> String {
+        match *self {
+            ICMP => "ICMP".to_string(),
+            TCP => "TCP".to_string(),
+            UDP => "UDP".to_string(),
+            DCCP => "DCCP".to_string(),
+            ICMPV6 => "ICMPv6".to_string(),
+            SCTP => "SCTP".to_string(),
+            _ => self.to_string(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_ethertype_resolve() {
+        let expected = "IPv4";
+        let ipv4: Ethertype = 0x0800;
+        assert_eq!(ipv4.resolve(), expected);
+    }
+
+    #[test]
+    fn test_next_proto_resolve() {
+        let expected = "TCP";
+        let tcp: NextProto = 6;
+        assert_eq!(tcp.resolve(), expected);
+    }
+}


### PR DESCRIPTION
Now parses IPv6 extension headers so that we can find the layer 4 proto underneath (if present).
E.g. Previously a fragmented IPv6 packet would show (44) as the next proto, instead of the TCP/UDP/etc proto underneath.

Also includes some cleanup of "resolving" protocol numbers to strings.